### PR TITLE
Add crawling and OCR ingestion pipelines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ dependencies = [
   "fastapi>=0.115",
   "uvicorn>=0.30",
   "pydantic>=2.8",
+  "openai>=1.44",
+  "python-dotenv>=1.0",
 ]
 
 [project.optional-dependencies]
@@ -13,6 +15,8 @@ ingest = [
   "httpx>=0.27",
   "tenacity>=8.2",
   "playwright>=1.47",
+  "pillow>=10.4",
+  "pytesseract>=0.3.10",
 ]
 
 [tool.pytest.ini_options]

--- a/src/nutrigo_ai/api/routes/nutrition.py
+++ b/src/nutrigo_ai/api/routes/nutrition.py
@@ -1,8 +1,14 @@
 from fastapi import APIRouter
 
 from nutrigo_ai.api.schemas import (
+    CartImageAnalysisRequest,
     NutritionAnalysisRequest,
     NutritionAnalysisResponse,
+    StoreLinkAnalysisRequest,
+)
+from nutrigo_ai.ingestion.entry import (
+    build_menus_from_cart_image,
+    build_menus_from_store_link,
 )
 from nutrigo_ai.services.llm_service import analyze_menus_with_llm
 
@@ -13,18 +19,28 @@ router = APIRouter(
 
 
 @router.post("/store-link", response_model=NutritionAnalysisResponse)
-async def analyze_from_store_link(req: NutritionAnalysisRequest):
-    """
-    배달앱 가게 페이지 링크 기반 분석
-    """
-    req.source_type = "store_link"
-    return analyze_menus_with_llm(req)
+async def analyze_from_store_link(req: StoreLinkAnalysisRequest):
+    """배달앱 가게 페이지 링크 기반 분석"""
+
+    menus = build_menus_from_store_link(req)
+    analysis_req = NutritionAnalysisRequest(
+        source_type="store_link",
+        source_id=req.store_id or req.store_url,
+        user_goal=req.user_goal,
+        menus=menus,
+    )
+    return analyze_menus_with_llm(analysis_req)
 
 
 @router.post("/cart-image", response_model=NutritionAnalysisResponse)
-async def analyze_from_cart_image(req: NutritionAnalysisRequest):
-    """
-    장바구니 캡처(OCR) 기반 분석
-    """
-    req.source_type = "cart_image"
-    return analyze_menus_with_llm(req)
+async def analyze_from_cart_image(req: CartImageAnalysisRequest):
+    """장바구니 캡처(OCR) 기반 분석"""
+
+    menus = build_menus_from_cart_image(req)
+    analysis_req = NutritionAnalysisRequest(
+        source_type="cart_image",
+        source_id=req.capture_id or req.image_url,
+        user_goal=req.user_goal,
+        menus=menus,
+    )
+    return analyze_menus_with_llm(analysis_req)

--- a/src/nutrigo_ai/api/schemas.py
+++ b/src/nutrigo_ai/api/schemas.py
@@ -1,7 +1,7 @@
 
 from datetime import date
 from typing import List, Optional, Literal
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 # -----------------------------
@@ -73,6 +73,58 @@ class NutritionAnalysisResponse(BaseModel):
     analyses: List[MenuAnalysis]
     summary: str
     recommended_menu_ids: List[str]
+
+
+class StoreLinkAnalysisRequest(BaseModel):
+    """
+    배달앱 가게 링크를 기반으로 메뉴 목록을 수집한 뒤 영양 분석을 수행하기 위한 요청 바디.
+
+    - store_url: 실제 배달앱 가게 페이지 URL (배민/요기요 등)
+    - user_goal: 사용자 영양 목표
+    - menus: (선택) 이미 수집된 메뉴 텍스트가 있다면 전달. 비어있으면 서버가 기본 메뉴를 생성
+    """
+
+    store_url: str = Field(..., description="배달앱 가게 페이지 URL")
+    store_id: Optional[str] = Field(None, description="가게 식별자 (알고 있다면)")
+    address_text: Optional[str] = Field(
+        None, description="배달앱에 입력할 주소 텍스트 (예: 서울특별시 중구 세종대로)"
+    )
+    lat: Optional[float] = Field(None, description="주소 위도 (선택)")
+    lng: Optional[float] = Field(None, description="주소 경도 (선택)")
+    order_serving_type: Literal["delivery", "pickup"] = Field(
+        "delivery", description="요기요 주문 유형"
+    )
+    user_goal: UserGoal
+    menus: List[MenuText] = Field(
+        default_factory=list,
+        description="크롤링/전달된 메뉴 텍스트. 비어있으면 서버가 간단한 더미 메뉴를 생성",
+    )
+
+
+class CartImageAnalysisRequest(BaseModel):
+    """
+    배달앱 장바구니/주문 확인 캡처 이미지를 기반으로 OCR + 영양 분석을 수행하기 위한 요청 바디.
+
+    - image_url 또는 image_base64 둘 중 하나는 반드시 필요
+    - menus: (선택) OCR 결과가 이미 있다면 전달
+    """
+
+    image_url: Optional[str] = Field(None, description="장바구니 캡처 이미지 URL")
+    image_base64: Optional[str] = Field(
+        None, description="캡처 이미지 Base64 (데이터 URI 허용)"
+    )
+    capture_id: Optional[str] = Field(None, description="장바구니 캡처 식별자")
+    user_goal: UserGoal
+    menus: List[MenuText] = Field(
+        default_factory=list,
+        description="OCR 결과 메뉴 텍스트. 비어있으면 서버가 간단한 더미 메뉴를 생성",
+    )
+
+    @model_validator(mode="after")
+    def validate_image_source(self):
+        if not self.image_url and not self.image_base64:
+            raise ValueError("image_url 또는 image_base64 중 하나는 필요합니다.")
+        return self
 
 
 # -----------------------------

--- a/src/nutrigo_ai/ingestion/entry.py
+++ b/src/nutrigo_ai/ingestion/entry.py
@@ -1,0 +1,98 @@
+"""인입 오케스트레이션.
+
+배달앱 가게 링크 크롤링, 장바구니 캡처 OCR 파이프라인을 묶어
+LLM 영양 분석에 필요한 MenuText 리스트를 만든다. 외부 의존성(브라우저,
+Tesseract)이 없거나 실패해도 기본 더미 메뉴를 반환해 API가 깨지지 않도록
+설계했다.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from typing import Iterable, List
+
+from nutrigo_ai.api.schemas import CartImageAnalysisRequest, MenuText, StoreLinkAnalysisRequest
+from nutrigo_ai.ingestion.ocr import menus_from_cart_image
+from nutrigo_ai.ingestion.store_link import menus_from_store_link
+
+
+def _ensure_menu_ids(menus: Iterable[MenuText], prefix: str = "item") -> List[MenuText]:
+    """MenuText.id 가 비어 있으면 prefix 기반으로 채워 넣는다."""
+
+    normalized: List[MenuText] = []
+    for idx, menu in enumerate(menus, start=1):
+        menu_id = menu.id if getattr(menu, "id", None) else f"{prefix}-{idx}"
+        normalized.append(
+            MenuText(
+                id=menu_id,
+                name=menu.name,
+                description=menu.description,
+                price=menu.price,
+                category_hint=menu.category_hint,
+                option_text=menu.option_text,
+            )
+        )
+    return normalized
+
+
+def _fallback_menus(base_key: str) -> List[MenuText]:
+    """크롤링/ OCR 결과가 없을 때 기본적으로 제공할 더미 메뉴."""
+
+    digest = hashlib.sha256(base_key.encode("utf-8", errors="ignore")).hexdigest()[:6]
+    return _ensure_menu_ids(
+        [
+            MenuText(id=f"{digest}-1", name="시그니처 메뉴", description="추천 인기 메뉴"),
+            MenuText(id=f"{digest}-2", name="가벼운 식사 세트", description="부담 없는 한 끼"),
+            MenuText(id=f"{digest}-3", name="든든한 단백질 플레이트", description="단백질 보충용"),
+        ]
+    )
+
+
+def build_menus_from_store_link(req: StoreLinkAnalysisRequest) -> List[MenuText]:
+    """
+    가게 링크 기반으로 메뉴 목록을 확보한다.
+
+    1) 메뉴 배열이 이미 전달되면 ID를 정규화하여 사용한다.
+    2) 배달앱 크롤러(yogiyo) 실행을 시도한다.
+    3) 모두 실패하면 URL 해시 기반의 더미 메뉴를 반환한다.
+    """
+
+    if req.menus:
+        return _ensure_menu_ids(req.menus, prefix=req.store_id or "store")
+
+    crawled = menus_from_store_link(req)
+    if crawled:
+        return _ensure_menu_ids(crawled, prefix=req.store_id or "store")
+
+    return _fallback_menus(req.store_id or req.store_url)
+
+
+def build_menus_from_cart_image(req: CartImageAnalysisRequest) -> List[MenuText]:
+    """
+    장바구니 캡처 기반으로 메뉴 목록을 확보한다.
+
+    - menus 가 이미 들어왔다면 그것을 정규화한다.
+    - OCR 파이프라인을 통해 텍스트를 추출 후 메뉴 후보를 만든다.
+    - 실패 시 기본 메뉴를 반환한다.
+    """
+
+    if req.menus:
+        return _ensure_menu_ids(req.menus, prefix=req.capture_id or "cart")
+
+    ocr_menus = menus_from_cart_image(req)
+    if ocr_menus:
+        return _ensure_menu_ids(ocr_menus, prefix=req.capture_id or "cart")
+
+    base_key = req.capture_id or req.image_url or "cart-image"
+
+    # image_base64 가 들어왔다면 해시를 안정적으로 만들기 위해 디코드만 시도한다.
+    if req.image_base64:
+        try:
+            decoded = base64.b64decode(req.image_base64.split(",")[-1], validate=False)
+            base_key = f"{base_key}-{hashlib.sha256(decoded).hexdigest()[:6]}"
+        except Exception:
+            pass
+
+    return _fallback_menus(base_key)
+

--- a/src/nutrigo_ai/ingestion/ocr.py
+++ b/src/nutrigo_ai/ingestion/ocr.py
@@ -1,0 +1,114 @@
+"""장바구니 캡처 OCR 파이프라인."""
+
+from __future__ import annotations
+
+import base64
+import io
+import importlib.util
+import re
+from typing import Iterable, List, Optional
+
+import httpx
+
+from nutrigo_ai.api.schemas import CartImageAnalysisRequest, MenuText
+
+
+def _pillow_available() -> bool:
+    return importlib.util.find_spec("PIL") is not None
+
+
+def _pytesseract_available() -> bool:
+    return importlib.util.find_spec("pytesseract") is not None
+
+
+def _load_image_from_url(url: str):
+    resp = httpx.get(url, timeout=10)
+    resp.raise_for_status()
+    return resp.content
+
+
+def _load_image_from_base64(encoded: str) -> bytes:
+    body = encoded.split(",")[-1]
+    return base64.b64decode(body, validate=False)
+
+
+def _read_image_bytes(req: CartImageAnalysisRequest) -> Optional[bytes]:
+    if req.image_base64:
+        try:
+            return _load_image_from_base64(req.image_base64)
+        except Exception:
+            return None
+    if req.image_url:
+        try:
+            return _load_image_from_url(req.image_url)
+        except Exception:
+            return None
+    return None
+
+
+def _image_to_text(img_bytes: bytes) -> str:
+    if not (_pillow_available() and _pytesseract_available()):
+        return ""
+
+    from PIL import Image
+    import pytesseract
+
+    with Image.open(io.BytesIO(img_bytes)) as image:
+        image = image.convert("RGB")
+        try:
+            return pytesseract.image_to_string(image, lang="kor+eng")
+        except Exception:
+            return pytesseract.image_to_string(image)
+
+
+def _extract_menu_lines(text: str) -> List[str]:
+    lines = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        # 가격 숫자 / 메뉴명 같이 있는 줄만 남긴다
+        if re.search(r"\d", line) or re.search(r"[가-힣a-zA-Z]", line):
+            lines.append(line)
+    return lines
+
+
+def _lines_to_menus(lines: Iterable[str]) -> List[MenuText]:
+    menus: List[MenuText] = []
+    for idx, line in enumerate(lines, start=1):
+        price_matches = list(re.finditer(r"(\d[\d,]{2,})", line))
+        price = None
+        if price_matches:
+            try:
+                price = int(price_matches[-1].group(1).replace(",", ""))
+            except Exception:
+                price = None
+        name = line
+        if price_matches:
+            name = line[: price_matches[0].start()].strip() or line
+        menus.append(
+            MenuText(
+                id=f"ocr-{idx}",
+                name=name,
+                description="OCR 추출",  # 간단 설명
+                price=price,
+                category_hint=None,
+                option_text=None,
+            )
+        )
+    return menus
+
+
+def menus_from_cart_image(req: CartImageAnalysisRequest) -> List[MenuText]:
+    """OCR을 통해 CartImageAnalysisRequest → MenuText[]."""
+
+    image_bytes = _read_image_bytes(req)
+    if not image_bytes:
+        return []
+
+    text = _image_to_text(image_bytes)
+    lines = _extract_menu_lines(text)
+    menus = _lines_to_menus(lines)
+
+    return menus
+

--- a/src/nutrigo_ai/ingestion/ocr.py
+++ b/src/nutrigo_ai/ingestion/ocr.py
@@ -8,8 +8,6 @@ import importlib.util
 import re
 from typing import Iterable, List, Optional
 
-import httpx
-
 from nutrigo_ai.api.schemas import CartImageAnalysisRequest, MenuText
 
 
@@ -21,7 +19,20 @@ def _pytesseract_available() -> bool:
     return importlib.util.find_spec("pytesseract") is not None
 
 
+def _httpx_client():
+    try:
+        import httpx
+
+        return httpx
+    except Exception:
+        return None
+
+
 def _load_image_from_url(url: str):
+    httpx = _httpx_client()
+    if httpx is None:
+        return None
+
     resp = httpx.get(url, timeout=10)
     resp.raise_for_status()
     return resp.content

--- a/src/nutrigo_ai/ingestion/store_link.py
+++ b/src/nutrigo_ai/ingestion/store_link.py
@@ -1,0 +1,57 @@
+"""배달앱 스토어 링크 크롤링 진입점."""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional
+from urllib.parse import urlparse
+
+from nutrigo_ai.api.schemas import MenuText, StoreLinkAnalysisRequest
+from nutrigo_ai.ingestion.sources.yogiyo import fetch_store_info, menu_json_to_menu_texts
+
+
+DEFAULT_LAT = 37.5665
+DEFAULT_LNG = 126.978
+DEFAULT_ADDRESS = "서울특별시 중구 세종대로"
+
+
+def _is_yogiyo(url: str) -> bool:
+    hostname = urlparse(url).hostname or ""
+    return "yogiyo" in hostname
+
+
+def _extract_yogiyo_id(url: str) -> Optional[str]:
+    path = urlparse(url).path
+    for token in path.split("/"):
+        if token.isdigit():
+            return token
+    match = re.search(r"/(\d+)(?:/|$)", path)
+    return match.group(1) if match else None
+
+
+def menus_from_store_link(req: StoreLinkAnalysisRequest) -> List[MenuText]:
+    """스토어 링크를 실제 크롤링해 MenuText 리스트를 만든다."""
+
+    if not req.store_url:
+        return []
+
+    if _is_yogiyo(req.store_url):
+        store_id = req.store_id or _extract_yogiyo_id(req.store_url)
+        if not store_id:
+            return []
+
+        result = fetch_store_info(
+            store_id=store_id,
+            address_text=req.address_text or DEFAULT_ADDRESS,
+            lat=req.lat if req.lat is not None else DEFAULT_LAT,
+            lng=req.lng if req.lng is not None else DEFAULT_LNG,
+            order_serving_type=req.order_serving_type,
+            headless=True,
+            pause_on_finish=False,
+        )
+        if not result:
+            return []
+        return menu_json_to_menu_texts(result["menu_json"])
+
+    return []
+

--- a/src/nutrigo_ai/ingestion/store_link.py
+++ b/src/nutrigo_ai/ingestion/store_link.py
@@ -6,8 +6,9 @@ import re
 from typing import List, Optional
 from urllib.parse import urlparse
 
+from typing import TYPE_CHECKING
+
 from nutrigo_ai.api.schemas import MenuText, StoreLinkAnalysisRequest
-from nutrigo_ai.ingestion.sources.yogiyo import fetch_store_info, menu_json_to_menu_texts
 
 
 DEFAULT_LAT = 37.5665
@@ -29,6 +30,17 @@ def _extract_yogiyo_id(url: str) -> Optional[str]:
     return match.group(1) if match else None
 
 
+def _yogiyo_helpers():
+    if TYPE_CHECKING:
+        from nutrigo_ai.ingestion.sources.yogiyo import fetch_store_info, menu_json_to_menu_texts
+
+    try:
+        from nutrigo_ai.ingestion.sources.yogiyo import fetch_store_info, menu_json_to_menu_texts
+    except Exception:
+        return None, None
+    return fetch_store_info, menu_json_to_menu_texts
+
+
 def menus_from_store_link(req: StoreLinkAnalysisRequest) -> List[MenuText]:
     """스토어 링크를 실제 크롤링해 MenuText 리스트를 만든다."""
 
@@ -36,22 +48,33 @@ def menus_from_store_link(req: StoreLinkAnalysisRequest) -> List[MenuText]:
         return []
 
     if _is_yogiyo(req.store_url):
+        fetch_store_info, menu_json_to_menu_texts = _yogiyo_helpers()
+        if not (fetch_store_info and menu_json_to_menu_texts):
+            return []
+
         store_id = req.store_id or _extract_yogiyo_id(req.store_url)
         if not store_id:
             return []
 
-        result = fetch_store_info(
-            store_id=store_id,
-            address_text=req.address_text or DEFAULT_ADDRESS,
-            lat=req.lat if req.lat is not None else DEFAULT_LAT,
-            lng=req.lng if req.lng is not None else DEFAULT_LNG,
-            order_serving_type=req.order_serving_type,
-            headless=True,
-            pause_on_finish=False,
-        )
+        try:
+            result = fetch_store_info(
+                store_id=store_id,
+                address_text=req.address_text or DEFAULT_ADDRESS,
+                lat=req.lat if req.lat is not None else DEFAULT_LAT,
+                lng=req.lng if req.lng is not None else DEFAULT_LNG,
+                order_serving_type=req.order_serving_type,
+                headless=True,
+                pause_on_finish=False,
+            )
+        except Exception:
+            return []
+
         if not result:
             return []
-        return menu_json_to_menu_texts(result["menu_json"])
+        try:
+            return menu_json_to_menu_texts(result["menu_json"])
+        except Exception:
+            return []
 
     return []
 


### PR DESCRIPTION
## Summary
- add yogurt store link crawling pipeline to feed menu texts from Yogiyo links
- introduce cart image OCR pipeline that extracts menus from screenshots with graceful fallbacks
- wire ingestion entrypoints to use real crawling/OCR before falling back to placeholder menus and expand store-link schema

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693806dbe5488330be7c9350242bb8d8)