### PR TITLE
feat: S3 키 또는 URL 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ python -m playwright install chromium
 
   * FastAPI 실행 포트 (기본 8000).
 
+* S3 입력 사용 시
+  * `S3_BUCKET` (권장): `image_url`로 키만 전달해도 S3에서 바로 읽어옵니다.
+  * `S3_REGION`, `S3_ENDPOINT` (옵션)
+  * `S3_FORCE_PATH_STYLE` (옵션, 기본 false)
+
 -> 노션 확인
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ Pillow>=10.0.0
 pytesseract>=0.3.10
 
 playwright>=1.48.0
+
+# S3 access
+boto3>=1.35.0

--- a/src/nutrigo_ai/core/config.py
+++ b/src/nutrigo_ai/core/config.py
@@ -3,3 +3,9 @@ import os
 APP_NAME = "NutriGo AI"
 APP_VERSION = os.getenv("MODEL_VERSION", "dev-0.0.1")
 PORT = int(os.getenv("PORT", "8000"))
+
+# S3 configuration (used for fetching uploaded images)
+S3_BUCKET = os.getenv("S3_BUCKET")
+S3_REGION = os.getenv("S3_REGION")
+S3_ENDPOINT = os.getenv("S3_ENDPOINT")
+S3_FORCE_PATH_STYLE = os.getenv("S3_FORCE_PATH_STYLE", "false").lower() == "true"

--- a/src/nutrigo_ai/ingestion/ocr.py
+++ b/src/nutrigo_ai/ingestion/ocr.py
@@ -9,6 +9,7 @@ import re
 from typing import Iterable, List, Optional
 
 from nutrigo_ai.api.schemas import CartImageAnalysisRequest, MenuText
+from nutrigo_ai.core import config
 
 
 def _pillow_available() -> bool:
@@ -28,6 +29,26 @@ def _httpx_client():
         return None
 
 
+def _boto3_client():
+    try:
+        import boto3
+        from botocore.config import Config as BotoConfig
+
+        session = boto3.session.Session(region_name=config.S3_REGION)
+        cfg = BotoConfig(
+            s3={
+                "addressing_style": "path" if config.S3_FORCE_PATH_STYLE else "virtual",
+            }
+        )
+        return session.client(
+            "s3",
+            endpoint_url=config.S3_ENDPOINT,
+            config=cfg,
+        )
+    except Exception:
+        return None
+
+
 def _load_image_from_url(url: str):
     httpx = _httpx_client()
     if httpx is None:
@@ -36,6 +57,41 @@ def _load_image_from_url(url: str):
     resp = httpx.get(url, timeout=10)
     resp.raise_for_status()
     return resp.content
+
+
+def _load_image_from_s3(url: str) -> Optional[bytes]:
+    """
+    지원 형태:
+      - s3://bucket/key
+      - 키만 전달된 경우(default bucket 필요)
+    """
+    client = _boto3_client()
+    if client is None:
+        return None
+
+    bucket = None
+    key = None
+
+    if url.startswith("s3://"):
+        # s3://bucket/key...
+        without_scheme = url[len("s3://") :]
+        parts = without_scheme.split("/", 1)
+        if len(parts) == 2:
+            bucket, key = parts[0], parts[1]
+    else:
+        # http/https 아닌 경우 키로 취급
+        if not url.startswith("http"):
+            bucket = config.S3_BUCKET
+            key = url
+
+    if not bucket or not key:
+        return None
+
+    try:
+        obj = client.get_object(Bucket=bucket, Key=key)
+        return obj["Body"].read()
+    except Exception:
+        return None
 
 
 def _load_image_from_base64(encoded: str) -> bytes:
@@ -50,6 +106,10 @@ def _read_image_bytes(req: CartImageAnalysisRequest) -> Optional[bytes]:
         except Exception:
             return None
     if req.image_url:
+        # 먼저 S3 시도 -> 실패 시 일반 URL GET
+        s3_bytes = _load_image_from_s3(req.image_url)
+        if s3_bytes:
+            return s3_bytes
         try:
             return _load_image_from_url(req.image_url)
         except Exception:


### PR DESCRIPTION
image_url이 S3 키 또는 s3://bucket/key일 때 S3에서 직접 fetch 후 OCR
boto3 의존성 추가, config에 S3 설정 노출
기존 cart/order OCR·LLM 파이프라인 그대로 사용, presigned 업로드 흐름과 호환